### PR TITLE
Locking feature and policies

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -453,6 +453,64 @@ class Container
 	}
 
 	/**
+	 * Method to check if a key is shared
+	 *
+	 * @param   string  $key  Name of the dataStore key to check.
+	 *
+	 * @return  boolean  TRUE if the key is shared
+	 */
+	public function isShared($key)
+	{
+		return (isset($this->dataStore[$key]) && $this->dataStore[$key]['shared'] === true);
+	}
+
+	/**
+	 * Method to check if a key is protected
+	 *
+	 * @param   string  $key  Name of the dataStore key to check.
+	 *
+	 * @return  boolean  TRUE if the key is protected
+	 */
+	public function isProtected($key)
+	{
+		return (isset($this->dataStore[$key]) && $this->dataStore[$key]['protected'] === true);
+	}
+
+	/**
+	 * Method to check if a key is locked
+	 *
+	 * @param   string  $key  Name of the dataStore key to check.
+	 *
+	 * @return  boolean  TRUE if the key is locked
+	 */
+	public function isLocked($key)
+	{
+		return (isset($this->dataStore[$key]) && $this->dataStore[$key]['locked'] === true);
+	}
+
+	/**
+	 * Method to get container policies
+	 *
+	 * @return  integet  A bitmask of policies
+	 */
+	public function getPolicies()
+	{
+		return $this->policies;
+	}
+
+	/**
+	 * Method to check if a policy is active
+	 *
+	 * @param   integer  $policy  Policy to check
+	 *
+	 * @return  boolean  TRUE if the policy is active
+	 */
+	public function hasPolicy($policy)
+	{
+		return ($policy & $this->policies);
+	}
+
+	/**
 	 * Register a service provider to the container.
 	 *
 	 * @param   ServiceProviderInterface  $provider  The service provider to register.

--- a/src/Container.php
+++ b/src/Container.php
@@ -72,6 +72,7 @@ class Container
 	 * Constructor for the DI Container
 	 *
 	 * @param   Container  $parent  Parent for hierarchical containers.
+	 * @param   integer    $policy  Bitmask of policies to apply
 	 *
 	 * @since   1.0
 	 */
@@ -208,7 +209,7 @@ class Container
 			throw new \OutOfBoundsException(sprintf('Key %s is locked and can\'t be extended.', $key));
 		}
 
-		//Get the instance with ignoring the lock
+		// Get the instance with ignoring the lock
 		$raw = $this->getRaw($key, true);
 
 		if (is_null($raw))
@@ -304,7 +305,7 @@ class Container
 			{
 				throw new \OutOfBoundsException(sprintf('Key %s is locked and can\'t be overwritten.', $key));
 			}
-			elseif ($this->dataStore[$key]['shared'] === true && isset($this->instances[$key]) && ($this->policy & Container::DROP_SHARE_ON_REWRITE))
+			elseif ($this->dataStore[$key]['shared'] === true && isset($this->instances[$key]) && ($this->policy & self::DROP_SHARE_ON_REWRITE))
 			{
 				unset($this->instances[$key]);
 			}
@@ -409,7 +410,8 @@ class Container
 	/**
 	 * Get the raw data assigned to a key.
 	 *
-	 * @param   string  $key  The key for which to get the stored item.
+	 * @param   string   $key         The key for which to get the stored item.
+	 * @param   boolean  $ignoreLock  Allows to disable lock for internal calls
 	 *
 	 * @return  mixed
 	 *
@@ -421,9 +423,9 @@ class Container
 
 		if (isset($this->dataStore[$key]))
 		{
-			if (!$ignoreLock && ($this->policy & Container::LOCK_AFTER_GET))
+			if (!$ignoreLock && ($this->policy & self::LOCK_AFTER_GET))
 			{
-				//Lock the instance so it cannot be further overwritten
+				// Lock the instance so it cannot be further overwritten
 				$this->dataStore[$key]['locked'] = true;
 			}
 
@@ -519,7 +521,7 @@ class Container
 	 *
 	 * @since   1.0
 	 */
-	public function registerServiceProvider(ServiceProviderInterface $provider, $arguments = array())
+	public function registerServiceProvider(ServiceProviderInterface $provider)
 	{
 		$provider->register($this);
 


### PR DESCRIPTION
Added locking of instances that already been read to avoid unexpected behavior.
Also added dropping of shared instances on rewrite or extend for the same reason.
Example (before patch):
    $container->share('foo','bar');
    $bar = $container->get('foo'); //An instance is generated on this call
    //Some code after we may not expect that a key is shared
    $container->share('foo','baz'); //Code is valid
    $baz = $container->get('foo'); //bar is returned
    //The same is on extend
    $container->extend('foo', function($var) { return $var.'_1'; });
    $bar_1 = $container->get('foo'); //bar is returned anyway

Also policies added to disable new features