### PR TITLE
[fix] parent aliases not resolved on getRaw()

### DIFF
--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -178,11 +178,18 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 		// Set the foo property directly in the datastore
 		$refProp = $reflection->getProperty('dataStore');
 		$refProp->setAccessible(true);
-		$refProp->setValue($this->fixture, array('foo' => array(
-			'callback' => function() { return new \stdClass; },
-			'shared' => true,
-			'protected' => true
-		)));
+		$refProp->setValue(
+			$this->fixture,
+			array(
+				'foo' => array(
+					'callback'  => function() {
+						return (object) array('property' => 'value');
+					},
+					'shared'    => true,
+					'protected' => true
+				)
+			)
+		);
 
 		// Alias bar to foo
 		$refProp2 = $reflection->getProperty('aliases');
@@ -369,11 +376,18 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 		// Set the foo property directly in the datastore
 		$refProp = $reflection->getProperty('dataStore');
 		$refProp->setAccessible(true);
-		$refProp->setValue($this->fixture, array('foo' => array(
-			'callback' => function() { return new \stdClass; },
-			'shared' => true,
-			'protected' => true
-		)));
+		$refProp->setValue(
+			$this->fixture,
+			array(
+				'foo' => array(
+					'callback' => function() {
+						return new \stdClass;
+					},
+					'shared' => true,
+					'protected' => true
+				)
+			)
+		);
 
 		// Alias bar to foo
 		$refProp2 = $reflection->getProperty('aliases');
@@ -907,7 +921,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 			'When calling exists on an item that has not been set in the container, it should return false.'
 		);
 	}
-
 
 	/**
 	 * Test getRaw

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -1023,4 +1023,105 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 			'When registering a service provider, the container instance should be returned.'
 		);
 	}
+
+	/**
+	 * Test that resolving and alias for a class from a parent container
+	 * returns the same object instance.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.3
+	 */
+	public function testResolveAliasOfParentContainer()
+	{
+		// Create a parent Container object
+		$parent = new Container;
+
+		$reflectionParent = new \ReflectionClass($parent);
+
+		// Set the foo property directly in the datastore
+		$refProp = $reflectionParent->getProperty('dataStore');
+		$refProp->setAccessible(true);
+		$refProp->setValue(
+			$parent,
+			array(
+				'foo' => array(
+					'callback'  => function() {
+						return (object) array('property' => 'value');
+					},
+					'shared'    => true,
+					'protected' => true
+				)
+			)
+		);
+
+		// Alias bar to foo
+		$refProp2 = $reflectionParent->getProperty('aliases');
+		$refProp2->setAccessible(true);
+		$refProp2->setValue($parent, array('bar' => 'foo'));
+
+		// Set a parent container
+		$reflectionChild = new \ReflectionClass($this->fixture);
+
+		$refParent = $reflectionChild->getProperty('parent');
+		$refParent->setAccessible(true);
+		$refParent->setValue($this->fixture, $parent);
+
+		$this->assertSame(
+			$this->fixture->get('foo'),
+			$this->fixture->get('bar'),
+			'When retrieving an alias of a class which calls the parent container, both the original and the alias should return the same object instance.'
+		);
+	}
+
+	/**
+	 * Test that resolving and alias for a class that is not shared from a parent container
+	 * returns the same object instance.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.3
+	 */
+	public function testResolveAliasOfNotSharedKeyFromParentContainer()
+	{
+		// Create a parent Container object
+		$parent = new Container;
+
+		$reflectionParent = new \ReflectionClass($parent);
+
+		// Set the foo property directly in the datastore
+		$refProp = $reflectionParent->getProperty('dataStore');
+		$refProp->setAccessible(true);
+		$refProp->setValue(
+			$parent,
+			array(
+				'foo' => array(
+					'callback'  => function() {
+						return (object) array('property' => 'value');
+					},
+					'shared'    => false,
+					'protected' => false
+				)
+			)
+		);
+
+		// Alias bar to foo
+		$refProp2 = $reflectionParent->getProperty('aliases');
+		$refProp2->setAccessible(true);
+		$refProp2->setValue($parent, array('bar' => 'foo'));
+
+		// Set a parent container
+		$reflectionChild = new \ReflectionClass($this->fixture);
+
+		$refParent = $reflectionChild->getProperty('parent');
+		$refParent->setAccessible(true);
+		$refParent->setValue($this->fixture, $parent);
+
+		$this->assertEquals(
+			$this->fixture->get('foo'),
+			$this->fixture->get('bar'),
+			'When retrieving an alias of a class which calls the parent container, and the key is not shared,'
+			. ' both the original and the alias should return a similar object.'
+		);
+	}
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -95,6 +95,11 @@ class Container
 			return $this->aliases[$key];
 		}
 
+		if ($this->parent instanceof Container)
+		{
+			return $this->parent->resolveAlias($key);
+		}
+
 		return $key;
 	}
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -389,7 +389,15 @@ class Container
 		{
 			return $this->dataStore[$key];
 		}
-		elseif ($this->parent instanceof Container)
+
+		$aliasKey = $this->resolveAlias($key);
+
+		if ($aliasKey != $key && isset($this->dataStore[$aliasKey]))
+		{
+			return $this->dataStore[$aliasKey];
+		}
+
+		if ($this->parent instanceof Container)
 		{
 			return $this->parent->getRaw($key);
 		}


### PR DESCRIPTION
Commit https://github.com/joomla-framework/di/commit/73cc4e1d26ebd7aa8a0a2eea52031b2b42dab22a#diff-5772c249f61507a501a28c2087d7d2a8L384 removed the `resolveAlias()` from `getRaw()` causing that parent containers aliases are never found.

Related: https://github.com/ventoviro/windwalker-joomla-rad/pull/118