### PR TITLE
Added support for parameters when getting a resource from the container

### DIFF
--- a/Tests/ContainerAccessTest.php
+++ b/Tests/ContainerAccessTest.php
@@ -89,4 +89,90 @@ class ContainerAccessTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertNotSame($container->getNewInstance('foo'), $container->getNewInstance('foo'));
 	}
+
+	/**
+	 * @testdox Getting an object with parameters from the container
+	 */
+	public function testGetWithParameters()
+	{
+		$container = new Container();
+		$container->set(
+			'foo',
+			function ($container, $parameter1, $parameter2)
+			{
+				if (!$container instanceof Container)
+					throw new \InvalidArgumentException('Illegal argument, first parameter must be a container!');
+
+				return $parameter1 . ' ' . $parameter2;
+			}
+		);
+
+		$this->assertSame('joomla di', $container->get('foo', 'joomla', 'di'));
+	}
+
+	/**
+	 * @testdox Getting a shared item with parameters from the container
+	 */
+	public function testGetWithParametersShared()
+	{
+		$container = new Container();
+		$container->set(
+			'foo',
+			function ($container, $parameter1 = null, $parameter2 = null)
+			{
+				if (!$container instanceof Container)
+					throw new \InvalidArgumentException('Illegal argument, first parameter must be a container!');
+
+				return $parameter1 . ' ' . $parameter2;
+			},
+			true
+		);
+
+		$this->assertSame(' ', $container->get('foo'));
+		$this->assertSame('joomla di', $container->get('foo', 'joomla', 'di'));
+		$this->assertSame('joomla2 di2', $container->get('foo', 'joomla2', 'di2'));
+	}
+
+	/**
+	 * @testdox Getting an object with object parameters from the container
+	 */
+	public function testGetWithParametersSharedObjectParameter()
+	{
+		$container = new Container();
+		$container->set(
+			'foo',
+			function ($container, $object1)
+			{
+				if (!$container instanceof Container)
+					throw new \InvalidArgumentException('Illegal argument, first parameter must be a container!');
+
+				return $object1;
+			},
+			true
+		);
+
+		$object = new \stdClass();
+		$object->foo = 'bar';
+		$this->assertSame($object, $container->get('foo', $object));
+		$this->assertSame($object, $container->get('foo', $object));
+		$this->assertSame(null, $container->get('foo', null));
+		$this->assertNotSame($object, $container->get('foo', new \stdClass()));
+	}
+
+	/**
+	 * @testdox Getting an object with object parameters from the container
+	 */
+	public function testGetWithParametersSharedNoCallable()
+	{
+		$container = new Container();
+		$container->set(
+			'foo',
+			'bar',
+			true
+		);
+
+		$this->assertSame('bar', $container->get('foo', 'test'));
+		$this->assertSame('bar', $container->get('foo', null));
+	}
+
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -64,6 +64,8 @@ class Container implements ContainerInterface
 	/**
 	 * Retrieve a resource
 	 *
+	 * A variable number of arguments are supported which are passed to the resource callable.
+	 *
 	 * @param   string  $resourceName  Name of the resource to get.
 	 *
 	 * @return  mixed  The requested resource
@@ -85,7 +87,10 @@ class Container implements ContainerInterface
 			throw new KeyNotFoundException(sprintf("Resource '%s' has not been registered with the container.", $resourceName));
 		}
 
-		return $this->resources[$key]->getInstance();
+		$arguments = func_get_args();
+		array_splice($arguments, 0, 1);
+
+		return call_user_func_array(array($this->resources[$key], 'getInstance'), $arguments);
 	}
 
 	/**


### PR DESCRIPTION
This PR adds support for a variable number of arguments passed to the container get function, when requesting a resource.

This is needed for Joomla 4 to replace JFactory functions like [getCache](https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/factory.php#L268) which do accept arguments. Additionally the singleton functions getInstance all over Joomla can be replaced with this PR too.

