### PR TITLE
Allow unsetting of a resource by setting the value to null

### DIFF
--- a/Tests/ContainerSetupTest.php
+++ b/Tests/ContainerSetupTest.php
@@ -267,4 +267,27 @@ class ContainerSetupTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($container, $container->get('foo'));
 	}
 
+	/**
+	 * @testdox The setting an object and then setting it again as null should remove the object
+	 * @expectedException  \Joomla\DI\Exception\KeyNotFoundException
+	 */
+	public function testSettingNullUnsetsAResource()
+	{
+		$container = new Container();
+		$container->set(
+			'foo',
+			function ()
+			{
+				return 'original';
+			}
+		);
+		$this->assertEquals('original', $container->get('foo'));
+
+		$container->set(
+			'foo',
+			null
+		);
+
+		$container->get('foo');
+	}
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -422,7 +422,7 @@ class Container implements ContainerInterface
 	}
 
 	/**
-	 * Set a resource
+	 * Set a resource. If the value is null unsets the resource.
 	 *
 	 * @param   string   $key        Name of resources key to set.
 	 * @param   mixed    $value      Callable function to run or string to retrive when requesting the specified $key.
@@ -441,6 +441,12 @@ class Container implements ContainerInterface
 		if ($this->has($key) && $this->isProtected($key))
 		{
 			throw new ProtectedKeyException(sprintf("Key %s is protected and can't be overwritten.", $key));
+		}
+		elseif ($this->has($key) && $value === null)
+		{
+			unset($this->resources[$key]);
+
+			return $this;
 		}
 
 		$mode = $shared ? Resource::SHARE : Resource::NO_SHARE;


### PR DESCRIPTION
Allows removal of a resource by setting the value to null. This is the same response as in the Symfony DI (https://github.com/symfony/dependency-injection/blob/master/Container.php#L174-L176)