### PR TITLE
Allow any callable for extend, docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,9 @@ Inversion of Control (IoC) Container for your application.
 Simply run the following from the command line in your project's root directory (where your `composer.json` file is):
 
 ```sh
-composer require joomla/di "2.0.*@dev"
+composer require joomla/di
 ```
-
-Alternatively, you can manually add `"joomla/di": "2.0.*@dev"` to the require block in your `composer.json`
-and then run `composer install`.
-
-```json
-{
-	"require": {
-		"joomla/di": "2.0.*@dev"
-	}
-}
-```
-
-## Upgrade from 1.x to 2.0
-
-  - The `exists` method was renamed to `has`. Change the method name.
-  - The second (optional) argument on `get` to enforce recreation on shared resources was removed. Use `getNewInstance` instead.
-  
-## Documentation
-
-  1. [Overview](docs/overview.md)
-  2. [Why Dependency Injection](docs/why-dependency-injection.md)
-  
 ## Contributing
 
-Please review [http://framework.joomla.org/contribute](http://framework.joomla.org/contribute) for information
+Please review [https://framework.joomla.org/contribute](https://framework.joomla.org/contribute) for information
 on how to contribute to the Framework's development.

--- a/Tests/ResourceDecorationTest.php
+++ b/Tests/ResourceDecorationTest.php
@@ -17,9 +17,16 @@ include_once 'Stubs/stubs.php';
 class ResourceDecoration extends TestCase
 {
 	/**
-	 * @testdox An extended resource replaces the original resource
+	 * Value used within resource methods
+	 *
+	 * @var  integer
 	 */
-	public function testExtend()
+	private $value = 42;
+
+	/**
+	 * @testdox An extended resource replaces the original resource with a Closure
+	 */
+	public function testExtendClosure()
 	{
 		$container = new Container();
 		$container->share(
@@ -30,23 +37,46 @@ class ResourceDecoration extends TestCase
 			}
 		);
 
-		$value = 42;
-
 		$container->extend(
 			'foo',
-			function ($shared) use ($value)
+			function ($shared)
 			{
-				$shared->value = $value;
+				$shared->value = $this->value;
 
 				return $shared;
 			}
 		);
 
 		$one = $container->get('foo');
-		$this->assertEquals($value, $one->value);
+		$this->assertEquals($this->value, $one->value);
 
 		$two = $container->get('foo');
-		$this->assertEquals($value, $two->value);
+		$this->assertEquals($this->value, $two->value);
+
+		$this->assertSame($one, $two);
+	}
+
+	/**
+	 * @testdox An extended resource replaces the original resource with a callback function
+	 */
+	public function testExtendCallback()
+	{
+		$container = new Container();
+		$container->share(
+			'foo',
+			[$this, 'baseCallable']
+		);
+
+		$container->extend(
+			'foo',
+			[$this, 'decoratingCallable']
+		);
+
+		$one = $container->get('foo');
+		$this->assertEquals($this->value, $one->value);
+
+		$two = $container->get('foo');
+		$this->assertEquals($this->value, $two->value);
 
 		$this->assertSame($one, $two);
 	}
@@ -98,16 +128,38 @@ class ResourceDecoration extends TestCase
 			}
 		);
 
-		$value = 42;
-
 		$container->extend(
 			'foo',
-			function ($shared) use ($value)
+			function ($shared)
 			{
-				$shared->value = $value;
+				$shared->value = $this->value;
 
 				return $shared;
 			}
 		);
+	}
+
+	/**
+	 * A base method defining a resource in a container
+	 *
+	 * @return  \stdClass
+	 */
+	public function baseCallable()
+	{
+		return new \stdClass;
+	}
+
+	/**
+	 * Method defining the decorating instruction for a container's resource
+	 *
+	 * @param   \stdClass  $shared  The return from the resource that was decorated
+	 *
+	 * @return  \stdClass
+	 */
+	public function decoratingCallable($shared)
+	{
+		$shared->value = $this->value;
+
+		return $shared;
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+* [Overview](overview.md)
+* [Updating from v1 to v2](v1-to-v2-update.md)
+* [Why Dependency Injection](why-dependency-injection.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -510,7 +510,7 @@ argument.
 The closure will receive 2 arguments.
 The first is result of the callable for the given key,
 and the second will be the container itself.
-<!-- [x] An extended resource replaces the original resource -->
+<!-- [x] An extended resource replaces the original resource with a Closure -->
 When extending an item, the new extended version overwrites the existing item in the container.
 
 ```php

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -1,0 +1,24 @@
+## Updating from v1 to v2
+
+### Minimum supported PHP version raised
+
+All framework packages now require PHP 5.5.9 or newer.
+
+### PSR-11 Support
+
+Version 2 of the DI package implements the [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md) `ContainerInterface`.
+
+### `Container::extend()` now allows any callable
+
+The `Joomla\DI\Container::extend()` method previously typehinted, and inherently required, a `Closure` instance for its
+decorating callback. The typehint on this method has been changed to `callable` and now allows any callable resource
+to serve as the decorator.
+
+### `Container::exists()` deprecated
+
+The `Joomla\DI\Container::exists()` method has been deprecated in favor of the PSR-11 defined `has()` method.
+
+### `Container::get()` signature changed
+
+The second (optional) argument on `Joomla\DI\Container::get()` to force recreation on shared resources was removed.
+Use `Joomla\DI\Container::getNewInstance()` instead.

--- a/src/Container.php
+++ b/src/Container.php
@@ -341,26 +341,27 @@ class Container implements ContainerInterface
 	}
 
 	/**
-	 * Extend a defined service Closure by wrapping the existing one with a new Closure.  This
-	 * works very similar to a decorator pattern.  Note that this only works on service Closures
+	 * Extend a defined service Closure by wrapping the existing one with a new callable function.
+	 *
+	 * This works very similar to a decorator pattern.  Note that this only works on service Closures
 	 * that have been defined in the current Provider, not parent providers.
 	 *
 	 * @param   string    $resourceName  The unique identifier for the Closure or property.
-	 * @param   \Closure  $callable      A Closure to wrap the original service Closure.
+	 * @param   callable  $callable      A callable to wrap the original service Closure.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public function extend($resourceName, \Closure $callable)
+	public function extend($resourceName, callable $callable)
 	{
 		$key = $this->resolveAlias($resourceName);
 		$resource = $this->getResource($key, true);
 
 		$closure = function ($c) use ($callable, $resource)
 		{
-			return $callable($resource->getInstance(), $c);
+			return call_user_func($callable, $resource->getInstance(), $c);
 		};
 
 		$this->set($key, $closure, $resource->isShared());


### PR DESCRIPTION
Pull Request for Issue #21

### Summary of Changes

- Updates the `extend()` method to allow any callable versus requiring a `Closure` (B/C break in the method signature)
- Starts the v1 to v2 upgrade doc
- Other minor docs updates