### PR TITLE
Deprecate the getter of the ContainerAwareInterface

### DIFF
--- a/src/ContainerAwareInterface.php
+++ b/src/ContainerAwareInterface.php
@@ -21,8 +21,8 @@ interface ContainerAwareInterface
 	 * @return  Container
 	 *
 	 * @since   1.0
-	 *
 	 * @throws  \UnexpectedValueException May be thrown if the container has not been set.
+	 * @deprecated  2.0  The getter will no longer be part of the interface.
 	 */
 	public function getContainer();
 

--- a/src/ContainerAwareTrait.php
+++ b/src/ContainerAwareTrait.php
@@ -8,13 +8,10 @@
 
 namespace Joomla\DI;
 
-use Joomla\DI\Container;
-
 /**
  * Defines the trait for a Container Aware Class.
  *
  * @since  1.2
- *
  * @note   Traits are available in PHP 5.4+
  */
 trait ContainerAwareTrait
@@ -33,8 +30,8 @@ trait ContainerAwareTrait
 	 * @return  Container
 	 *
 	 * @since   1.2
-	 *
 	 * @throws  \UnexpectedValueException May be thrown if the container has not been set.
+	 * @note    As of 2.0 this method will be protected.
 	 */
 	public function getContainer()
 	{


### PR DESCRIPTION
### Summary of Changes

The container should be an implementation detail of an object, not something that can be freely accessed from the outside.  Therefore, this PR does two things:

1) Deprecates `ContainerAwareInterface::getContainer()`, container aware objects no longer will automatically expose the container to the world.
2) Schedules `ContainerAwareTrait::getContainer()` to be protected in 2.0.  It's still a good shortcut for ensuring a container has been set to a container aware object (hence the reason I didn't fully deprecate), but the scope change goes to support the methodology change.

### Documentation Changes Required

2.0 upgrade guide should note these changes.