### PR TITLE
Add a method to expose all keys of the container

### DIFF
--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -1127,4 +1127,23 @@ class ContainerTest extends TestCase
 			. ' both the original and the alias should return a similar object.'
 		);
 	}
+
+	/**
+	 * Test that the unique service keys for the container are returned.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testRetrievingTheContainerKeys()
+	{
+		$this->fixture->set('foo', 'bar');
+		$this->fixture->set('goo', 'car');
+		$this->fixture->alias('boo', 'foo');
+
+		$this->assertSame(
+			array('boo', 'foo', 'goo'),
+			$this->fixture->getKeys()
+		);
+	}
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -441,4 +441,16 @@ class Container
 
 		return $this;
 	}
+
+	/**
+	 * Retrieve the keys for services assigned to this container.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getKeys()
+	{
+		return array_unique(array_merge(array_keys($this->aliases), array_keys($this->dataStore)));
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #29

### Summary of Changes

Creates a new `getKeys` method returning an array of service keys based on registered services and aliases.

### Testing Instructions

When running `$container->getKeys()`, you should receive an array with a combination of the unique service keys of registered services and aliases.