### PR TITLE
Fixed incorrect parameter type for protect() and share()

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -301,9 +301,9 @@ class Container
 	/**
 	 * Convenience method for creating protected keys.
 	 *
-	 * @param   string    $key       Name of dataStore key to set.
-	 * @param   mixed     $callback  Callable function to run when requesting the specified $key.
-	 * @param   bool      $shared    True to create and store a shared instance.
+	 * @param   string   $key     Name of dataStore key to set.
+	 * @param   mixed    $value   Callable function to run or string to retrive when requesting the specified $key.
+	 * @param   boolean  $shared  True to create and store a shared instance.
 	 *
 	 * @return  Container  This object for chaining.
 	 *
@@ -317,9 +317,9 @@ class Container
 	/**
 	 * Convenience method for creating shared keys.
 	 *
-	 * @param   string    $key        Name of dataStore key to set.
-	 * @param   mixed     $callback   Callable function to run when requesting the specified $key.
-	 * @param   bool      $protected  True to create and store a shared instance.
+	 * @param   string   $key        Name of dataStore key to set.
+	 * @param   mixed    $value      Callable function to run or string to retrive when requesting the specified $key.
+	 * @param   boolean  $protected  True to protect this item from being overwritten. Useful for services.
 	 *
 	 * @return  Container  This object for chaining.
 	 *

--- a/src/Container.php
+++ b/src/Container.php
@@ -302,7 +302,7 @@ class Container
 	 * Convenience method for creating protected keys.
 	 *
 	 * @param   string    $key       Name of dataStore key to set.
-	 * @param   callable  $callback  Callable function to run when requesting the specified $key.
+	 * @param   mixed     $callback  Callable function to run when requesting the specified $key.
 	 * @param   bool      $shared    True to create and store a shared instance.
 	 *
 	 * @return  Container  This object for chaining.
@@ -318,7 +318,7 @@ class Container
 	 * Convenience method for creating shared keys.
 	 *
 	 * @param   string    $key        Name of dataStore key to set.
-	 * @param   callable  $callback   Callable function to run when requesting the specified $key.
+	 * @param   mixed     $callback   Callable function to run when requesting the specified $key.
 	 * @param   bool      $protected  True to create and store a shared instance.
 	 *
 	 * @return  Container  This object for chaining.


### PR DESCRIPTION
These methods just proxy `set()`, which permits more than just `callable` types.

Please merge into 2.0 also.