### PR TITLE
Add support for tagged services

### DIFF
--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -205,6 +205,67 @@ class ContainerTest extends TestCase
 	}
 
 	/**
+	 * Test the tag method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testTag()
+	{
+		$this->fixture->tag('service', array('foo'));
+
+		$tags = $this->readAttribute($this->fixture, 'tags');
+
+		$this->assertEquals(
+			array('service' => array('foo')),
+			$tags,
+			'When setting a tag, it should be set in the $tags Container property.'
+		);
+	}
+
+	/**
+	 * Test the tag method with an aliased service.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testTagWithAliasedService()
+	{
+		$this->fixture->set('foo', 'bar');
+		$this->fixture->alias('goo', 'foo');
+		$this->fixture->tag('service', array('goo'));
+
+		$tags = $this->readAttribute($this->fixture, 'tags');
+
+		$this->assertEquals(
+			array('service' => array('foo')),
+			$tags,
+			'When setting a tag using an alias, the key stored to the $tags Container property should be the resolved service ID.'
+		);
+	}
+
+	/**
+	 * Test the getTagged method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetTagged()
+	{
+		$this->fixture->set('foo', 'bar');
+		$this->fixture->tag('service', array('foo'));
+
+		$this->assertEquals(
+			array('bar'),
+			$this->fixture->getTagged('service'),
+			'Resolved services for the named tag should be returned.'
+		);
+	}
+
+	/**
 	 * Tests the buildObject with no dependencies.
 	 *
 	 * @return  void

--- a/src/Container.php
+++ b/src/Container.php
@@ -20,7 +20,7 @@ class Container
 	/**
 	 * Holds the key aliases.
 	 *
-	 * @var    array  $aliases
+	 * @var    array
 	 * @since  1.0
 	 */
 	protected $aliases = array();
@@ -28,7 +28,7 @@ class Container
 	/**
 	 * Holds the shared instances.
 	 *
-	 * @var    array  $instances
+	 * @var    array
 	 * @since  1.0
 	 */
 	protected $instances = array();
@@ -37,7 +37,7 @@ class Container
 	 * Holds the keys, their callbacks, and whether or not
 	 * the item is meant to be a shared resource.
 	 *
-	 * @var    array  $dataStore
+	 * @var    array
 	 * @since  1.0
 	 */
 	protected $dataStore = array();
@@ -49,6 +49,14 @@ class Container
 	 * @since  1.0
 	 */
 	protected $parent;
+
+	/**
+	 * Holds the service tag mapping.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $tags = array();
 
 	/**
 	 * Constructor for the DI Container
@@ -101,6 +109,60 @@ class Container
 		}
 
 		return $key;
+	}
+
+	/**
+	 * Assign a tag to services.
+	 *
+	 * @param   string  $tag   The tag name
+	 * @param   array   $keys  The service keys to tag
+	 *
+	 * @return  Container  This object for chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function tag($tag, array $keys)
+	{
+		foreach ($keys as $key)
+		{
+			$resolvedKey = $this->resolveAlias($key);
+
+			if (!isset($this->tags[$tag]))
+			{
+				$this->tags[$tag] = array();
+			}
+
+			$this->tags[$tag][] = $resolvedKey;
+		}
+
+		// Prune duplicates
+		$this->tags[$tag] = array_unique($this->tags[$tag]);
+
+		return $this;
+	}
+
+	/**
+	 * Fetch all services registered to the given tag.
+	 *
+	 * @param   string  $tag  The tag name
+	 *
+	 * @return  array  The resolved services for the given tag
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTagged($tag)
+	{
+		$services = array();
+
+		if (isset($this->tags[$tag]))
+		{
+			foreach ($this->tags[$tag] as $service)
+			{
+				$services[] = $this->get($service);
+			}
+		}
+
+		return $services;
 	}
 
 	/**

--- a/src/Container.php
+++ b/src/Container.php
@@ -371,9 +371,9 @@ class Container
 	 *
 	 * @since   1.0
 	 */
-	public function protect($key, $callback, $shared = false)
+	public function protect($key, $value, $shared = false)
 	{
-		return $this->set($key, $callback, $shared, true);
+		return $this->set($key, $value, $shared, true);
 	}
 
 	/**
@@ -387,9 +387,9 @@ class Container
 	 *
 	 * @since   1.0
 	 */
-	public function share($key, $callback, $protected = false)
+	public function share($key, $value, $protected = false)
 	{
-		return $this->set($key, $callback, true, $protected);
+		return $this->set($key, $value, true, $protected);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Right now we lack a way to mark a group of services, as an example to fetch all services which are Twig extension classes.  This adds a tagging capability to the container to accomplish that.

### Testing Instructions

With the new API, you can do something like this:

```php
<?php
use Joomla\DI\Container;

$container = new Container;
$container->set('twig.extension.intl', new \Twig_Extensions_Extension_Intl);
$container->set('twig.extension.text', new \Twig_Extensions_Extension_Text);
$container->tag('twig.extensions', array('twig.extension.intl', 'twig.extension.text'));
$container->set('twig', function (Container $container) {
    $twig = new \Twig_Environment(new \Twig_Loader_Array);
    $twig->setExtensions($container->getTagged('twig.extensions'));

    return $twig;
});
```