### PR TITLE
[2.0] Fix deprecation notice on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla-framework/di",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|~8",
         "psr/container": "^1.0",
         "symfony/deprecation-contracts": "^2.1"
     },


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-framework/di/issues/38.

### Summary of Changes

Fixes "Deprecated: Method ReflectionParameter::getClass() is deprecated" notice on PHP 8.

### Testing Instructions

Tests pass, `Joomla\Container\Container::buildObject()` no longer emits notice on PHP 8.

### Documentation Changes Required

No.