### PR TITLE
Add possibility to override 'protected' item in Child container

### DIFF
--- a/Tests/ContainerSetupTest.php
+++ b/Tests/ContainerSetupTest.php
@@ -330,4 +330,36 @@ class ContainerSetupTest extends TestCase
 
 		$container->get('foo');
 	}
+
+	/**
+	 * @testdox  The method isLocal() works or not
+	 *
+	 * @covers   Joomla\DI\Container
+	 * @uses     Joomla\DI\ContainerResource
+	 */
+	public function testIsLocal()
+	{
+		$container = new Container;
+		$container->protect(
+			Stub1::class,
+			static function ()
+			{
+				return new Stub1;
+			}
+		);
+		$child = $container->createChild();
+		$child->set(
+			Stub4::class,
+			static function ()
+			{
+				return new Stub4;
+			}
+		);
+
+		$this->assertTrue($container->isLocal(Stub1::class), 'Root element inside Root container is local.');
+		$this->assertFalse($child->isLocal(Stub1::class), 'Root element inside Child container is not local.');
+
+		$this->assertTrue($child->isLocal(Stub4::class), 'Child element inside it`s container is local.');
+		$this->assertFalse($container->isLocal(Stub4::class), 'Child element inside Root container is not local.');
+	}
 }

--- a/Tests/HierachicalTest.php
+++ b/Tests/HierachicalTest.php
@@ -102,4 +102,32 @@ class HierachicalTest extends TestCase
 		$this->assertTrue($container->isShared('aic_foo'), "'aic_foo' is expected to be shared");
 		$this->assertTrue($container->isProtected('aic_foo'), "'aic_foo' is expected to be protected");
 	}
+
+	/**
+	 * @testdox  Test possibility to override 'protected' item in Child container
+	 *
+	 * @covers   Joomla\DI\Container
+	 * @uses     Joomla\DI\ContainerResource
+	 */
+	public function testOverrideProtectedItemLocaly()
+	{
+		$container = new Container;
+		$container->protect(
+			StubInterface::class,
+			static function ()
+			{
+				return new Stub1;
+			}
+		);
+		$child = $container->createChild();
+		$child->set(
+			StubInterface::class,
+			static function ()
+			{
+				return new Stub4;
+			}
+		);
+
+		$this->assertInstanceOf(Stub4::class, $child->get(StubInterface::class));
+	}
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -208,6 +208,22 @@ class Container implements ContainerInterface
 	}
 
 	/**
+	 * Check whether a resource is stored locally
+	 *
+	 * @param   string  $resourceName  Name of the resource to check.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function isLocal(string $resourceName): bool
+	{
+		$key = $this->resolveAlias($resourceName);
+
+		return !empty($this->resources[$key]);
+	}
+
+	/**
 	 * Check whether a flag (i.e., one of 'shared' or 'protected') is set
 	 *
 	 * @param   string   $resourceName  Name of the resource to check.
@@ -646,7 +662,7 @@ class Container implements ContainerInterface
 
 		$hasKey = $this->has($key);
 
-		if ($hasKey && $this->isProtected($key))
+		if ($hasKey && $this->isLocal($key) && $this->isProtected($key))
 		{
 			throw new ProtectedKeyException(sprintf("Key %s is protected and can't be overwritten.", $key));
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/40324 and https://github.com/joomla/joomla-cms/pull/40388

### Summary of Changes

Allow to overide resource if it not exist locally

### Testing Instructions

Unittest passes

### Documentation Changes Required

New feature