### PR TITLE
[4.x] Define services in more convenient and readable way

### DIFF
--- a/Tests/ContainerResourceDefinitionTest.php
+++ b/Tests/ContainerResourceDefinitionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright  Copyright (C) 2013 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\DI\Tests;
+
+use Joomla\DI\Container;
+use PHPUnit\Framework\TestCase;
+
+include_once __DIR__ . '/Stubs/stubs.php';
+
+/**
+ * Tests for ContainerResourceDefinition class.
+ */
+class ContainerResourceDefinitionTest extends TestCase
+{
+    /**
+     * @testdox  Defines services in convenient and readable way
+     *
+     * @covers   Joomla\DI\ContainerResourceDefinition
+     */
+    public function testDef(): void
+    {
+        $container = new Container();
+        $container->def('foo')
+            ->shared()
+            ->protected()
+            ->aliases(['bar', 'baz'])
+            ->tags(['tag1', 'tag2'])
+            ->factory(static function () {
+                return new Stub1();
+            })
+            ->end();
+
+
+        $foo = $container->get('foo');
+
+        $this->assertInstanceOf(Stub1::class, $foo);
+        $this->assertTrue($container->isShared('foo'));
+        $this->assertTrue($container->isProtected('foo'));
+
+        $this->assertSame($foo, $container->get('bar'));
+        $this->assertSame($foo, $container->get('baz'));
+
+        $this->assertSame([ $foo ], $container->getTagged('tag1'));
+        $this->assertSame([ $foo ], $container->getTagged('tag2'));
+    }
+
+    /**
+     * @testdox  Creates factory automatically
+     *
+     * @covers   Joomla\DI\ContainerResourceDefinition
+     */
+    public function testDefAutoFactory(): void
+    {
+        $container = new Container();
+        $container->def(Stub1::class)->end();
+
+        $stub1 = $container->get(Stub1::class);
+
+        $this->assertInstanceOf(Stub1::class, $stub1);
+    }
+
+    /**
+     * @testdox  Defines lazy services
+     *
+     * @covers   Joomla\DI\ContainerResourceDefinition
+     */
+    public function testDefLazy(): void
+    {
+        $container = new Container();
+
+        $container->def(StubInterface::class)
+            ->lazy(Stub2::class)
+            ->factory(static fn () => new Stub2(new Stub1()))
+            ->end();
+
+        $stub1 = $container->get(StubInterface::class);
+
+        if (PHP_VERSION_ID >= 80400) {
+            $this->assertTrue((new \ReflectionClass(Stub2::class))->isUninitializedLazyObject($stub1));
+        }
+
+        $this->assertInstanceOf(Stub2::class, $stub1);
+    }
+}

--- a/Tests/ContainerResourceDefinitionTest.php
+++ b/Tests/ContainerResourceDefinitionTest.php
@@ -65,6 +65,23 @@ class ContainerResourceDefinitionTest extends TestCase
     }
 
     /**
+     * @testdox  Creates factory automatically with dependency
+     *
+     * @covers   Joomla\DI\ContainerResourceDefinition
+     */
+    public function testDefAutoFactoryWithDependency(): void
+    {
+        $container = new Container();
+        $container->def(Stub4::class)->end();
+        $container->def(Stub5::class)->end();
+
+        $stub5 = $container->get(Stub5::class);
+
+        $this->assertInstanceOf(Stub5::class, $stub5);
+        $this->assertInstanceOf(Stub4::class, $stub5->stub);
+    }
+
+    /**
      * @testdox  Defines lazy services
      *
      * @covers   Joomla\DI\ContainerResourceDefinition

--- a/src/Container.php
+++ b/src/Container.php
@@ -568,6 +568,21 @@ class Container implements ContainerInterface
     }
 
     /**
+     * Define a resource (service).
+     *
+     * @param   string   $key  Name of resources key to set.
+     *
+     * @return  ContainerResourceDefinition
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  ProtectedKeyException  Thrown if the provided key is already set and is protected.
+     */
+    public function def(string $key): ContainerResourceDefinition
+    {
+        return new ContainerResourceDefinition($key, $this);
+    }
+
+    /**
      * Set a resource to the container. If the value is null the resource is removed.
      *
      * @param   string   $key        Name of resources key to set.

--- a/src/ContainerResourceDefinition.php
+++ b/src/ContainerResourceDefinition.php
@@ -213,6 +213,37 @@ class ContainerResourceDefinition
     }
 
     /**
+     * Apply the resource definition to the container.
+     *
+     * @return  Container
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function end(): Container
+    {
+        if ($this->lazy) {
+            $this->value = $this->container->lazy(
+                $this->lazyClass,
+                $this->value ?? $this->makeFactory($this->lazyClass),
+            );
+        } else {
+            $this->value = $this->value ?? $this->makeFactory($this->key);
+        }
+
+        $this->container->set($this->key, $this->value, $this->shared, $this->protected);
+
+        foreach ($this->aliases as $alias) {
+            $this->container->alias($alias, $this->key);
+        }
+
+        foreach ($this->tags as $tag) {
+            $this->container->tag($tag, [ $this->key ]);
+        }
+
+        return $this->container;
+    }
+
+    /**
      * Create a factory for the given class.
      *
      * @param   string  $class  The class name
@@ -255,36 +286,5 @@ class ContainerResourceDefinition
 
             return $reflection->newInstanceArgs($args);
         };
-    }
-
-    /**
-     * Apply the resource definition to the container.
-     *
-     * @return  Container
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function end(): Container
-    {
-        if ($this->lazy) {
-            $this->value = $this->container->lazy(
-                $this->lazyClass,
-                $this->value ?? $this->makeFactory($this->lazyClass),
-            );
-        } else {
-            $this->value = $this->value ?? $this->makeFactory($this->key);
-        }
-
-        $this->container->set($this->key, $this->value, $this->shared, $this->protected);
-
-        foreach ($this->aliases as $alias) {
-            $this->container->alias($alias, $this->key);
-        }
-
-        foreach ($this->tags as $tag) {
-            $this->container->tag($tag, [ $this->key ]);
-        }
-
-        return $this->container;
     }
 }

--- a/src/ContainerResourceDefinition.php
+++ b/src/ContainerResourceDefinition.php
@@ -213,6 +213,51 @@ class ContainerResourceDefinition
     }
 
     /**
+     * Create a factory for the given class.
+     *
+     * @param   string  $class  The class name
+     *
+     * @return  callable
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function makeFactory(string $class): callable
+    {
+        return function () use ($class) {
+            $reflection = new \ReflectionClass($class);
+            $constructor = $reflection->getConstructor();
+
+            if ($constructor === null) {
+                return new $class();
+            }
+
+            $args = [];
+
+            foreach ($constructor->getParameters() as $parameter) {
+                $type = $parameter->getType();
+
+                if ($type && !$type->isBuiltin()) {
+                    $typeName = $type->getName();
+
+                    if ($this->container->has($typeName)) {
+                        $args[] = $this->container->get($typeName);
+                        continue;
+                    }
+                }
+
+                if ($parameter->isDefaultValueAvailable()) {
+                    $args[] = $parameter->getDefaultValue();
+                    continue;
+                }
+
+                throw new \RuntimeException(sprintf('Cannot resolve dependency "%s" for class "%s"', $parameter->getName(), $class));
+            }
+
+            return $reflection->newInstanceArgs($args);
+        };
+    }
+
+    /**
      * Apply the resource definition to the container.
      *
      * @return  Container
@@ -224,10 +269,10 @@ class ContainerResourceDefinition
         if ($this->lazy) {
             $this->value = $this->container->lazy(
                 $this->lazyClass,
-                $this->value ?? fn () => new $this->lazyClass(),
+                $this->value ?? $this->makeFactory($this->lazyClass),
             );
         } else {
-            $this->value = $this->value ?? fn () => new $this->key();
+            $this->value = $this->value ?? $this->makeFactory($this->key);
         }
 
         $this->container->set($this->key, $this->value, $this->shared, $this->protected);

--- a/src/ContainerResourceDefinition.php
+++ b/src/ContainerResourceDefinition.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * Part of the Joomla Framework DI Package
+ *
+ * @copyright  Copyright (C) 2013 - 2025 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\DI;
+
+/**
+ * Defines services in convenient and readable way.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ContainerResourceDefinition
+{
+    /**
+    * Resource key.
+    *
+    * @var    string
+    * @since  __DEPLOY_VERSION__
+    */
+    private string $key;
+
+    /**
+    * Container for resource.
+    *
+    * @var    Container
+    * @since  __DEPLOY_VERSION__
+    */
+    private Container $container;
+
+    /**
+    * Resource value.
+    *
+    * @var    mixed
+    * @since  __DEPLOY_VERSION__
+    */
+    private $value = null;
+
+    /**
+    * Is resource shared?
+    *
+    * @var    bool
+    * @since  __DEPLOY_VERSION__
+    */
+    private bool $shared = false;
+
+    /**
+    * Is resource protected?
+    *
+    * @var    bool
+    * @since  __DEPLOY_VERSION__
+    */
+    private bool $protected = false;
+
+    /**
+    * Is resource lazy?
+    *
+    * @var    bool
+    * @since  __DEPLOY_VERSION__
+    */
+    private bool $lazy = false;
+
+    /**
+     * Full class name of the resource.
+    *
+    * @var    ?string
+    * @since  __DEPLOY_VERSION__
+    */
+    private ?string $lazyClass = null;
+
+    /**
+    * Resource aliases.
+    *
+    * @var    array
+    * @since  __DEPLOY_VERSION__
+    */
+    private array $aliases = [];
+
+    /**
+    * Resource tags.
+    *
+    * @var    array
+    * @since  __DEPLOY_VERSION__
+    */
+    private array $tags = [];
+
+    /**
+     * Constructor.
+     *
+     * @param   string     $key        Resource key
+     * @param   Container  $container  Resource container
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct(string $key, Container $container)
+    {
+        $this->key = $key;
+        $this->container = $container;
+    }
+
+    /**
+     * Set resource factory.
+     *
+     * @param   callable  $factory  Resource factory
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function factory(callable $factory): self
+    {
+        $this->value = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Set resource value.
+     *
+     * @param   mixed  $value  Resource value
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function value($value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set resource as shared.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function shared(): self
+    {
+        $this->shared = true;
+
+        return $this;
+    }
+
+    /**
+     * Set resource as protected.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function protected(): self
+    {
+        $this->protected = true;
+
+        return $this;
+    }
+
+    /**
+     * Set resource as lazy.
+     *
+     * @param   ?string  $class  Full class name of the resource.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function lazy(?string $class = null): self
+    {
+        $this->lazy = true;
+
+        $this->lazyClass = $class ?? $this->key;
+
+        return $this;
+    }
+
+    /**
+     * Set resource aliases.
+     *
+     * @param   array  $aliases  Array of aliases
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function aliases(array $aliases): self
+    {
+        $this->aliases = $aliases;
+
+        return $this;
+    }
+
+    /**
+     * Set resource tags.
+     *
+     * @param   array  $tags  Array of tags
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function tags(array $tags): self
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * Apply the resource definition to the container.
+     *
+     * @return  Container
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function end(): Container
+    {
+        if ($this->lazy) {
+            $this->value = $this->container->lazy(
+                $this->lazyClass,
+                $this->value ?? fn () => new $this->lazyClass(),
+            );
+        } else {
+            $this->value = $this->value ?? fn () => new $this->key();
+        }
+
+        $this->container->set($this->key, $this->value, $this->shared, $this->protected);
+
+        foreach ($this->aliases as $alias) {
+            $this->container->alias($alias, $this->key);
+        }
+
+        foreach ($this->tags as $tag) {
+            $this->container->tag($tag, [ $this->key ]);
+        }
+
+        return $this->container;
+    }
+}


### PR DESCRIPTION
### Summary of Changes

This PR introduces a new container method `def()` which returns a special resource builder allowing to configure service in a more convenient way using fluent interface:

```php
$container->def(CacheControllerFactoryInterface::class)
    ->shared()
    ->protected()
    ->lazy(CacheControllerFactory::class)
    ->factory(
        function (Container $container) {
            return new CacheControllerFactory();
        },
    )
    ->aliases([ 'cache.controller.factory', CacheControllerFactory::class ])
    ->tags([ 'cache_controller' ])
    ->end();
```

### Testing Instructions

Unit tests provided

### Documentation Changes Required

Yes