### PR TITLE
[3.x] Fix test class name

### DIFF
--- a/Tests/ResourceDecorationTest.php
+++ b/Tests/ResourceDecorationTest.php
@@ -17,7 +17,7 @@ include_once __DIR__ . '/Stubs/stubs.php';
 /**
  * Tests for Container class.
  */
-class ResourceDecoration extends TestCase
+class ResourceDecorationTest extends TestCase
 {
     /**
      * Value used within resource methods


### PR DESCRIPTION
### Summary of Changes

Test class `ResourceDecoration`  has been renamed to `ResourceDecorationTest`.

### Testing Instructions

Run `phpunit` and ensure that all tests pass

### Documentation Changes Required

No
