### PR TITLE
[4.x] Improve container extensibility

### DIFF
--- a/Tests/AliasingTest.php
+++ b/Tests/AliasingTest.php
@@ -31,8 +31,7 @@ class AliasingTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            true,
-            true
+            [ 'shared' => true, 'protected' => true ]
         );
         $container->alias('bar', 'foo');
 
@@ -57,8 +56,7 @@ class AliasingTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            true,
-            true
+            [ 'shared' => true, 'protected' => true ]
         );
         $container->alias('bar', 'foo');
 

--- a/Tests/ContainerAccessTest.php
+++ b/Tests/ContainerAccessTest.php
@@ -31,7 +31,7 @@ class ContainerAccessTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            true
+            [ 'shared' => true ],
         );
 
         $this->assertSame($container->get('foo'), $container->get('foo'));
@@ -51,7 +51,7 @@ class ContainerAccessTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            false
+            [ 'shared' => false ],
         );
 
         $this->assertNotSame($container->get('foo'), $container->get('foo'));

--- a/Tests/ContainerResourceTest.php
+++ b/Tests/ContainerResourceTest.php
@@ -21,43 +21,43 @@ class ContainerResourceTest extends TestCase
     public function dataInstantiation(): \Generator
     {
         yield 'shared, protected' => [
-            'mode'      => ContainerResource::SHARE | ContainerResource::PROTECT,
+            'mode'      => [ 'shared' => true, 'protected' => true ],
             'shared'    => true,
             'protected' => true,
         ];
 
         yield 'shared, not protected (explicit)' => [
-            'mode'      => ContainerResource::SHARE | ContainerResource::NO_PROTECT,
+            'mode'      => ['shared' => true, 'protected' => false],
             'shared'    => true,
             'protected' => false,
         ];
 
         yield 'not shared, protected (explicit)' => [
-            'mode'      => ContainerResource::NO_SHARE | ContainerResource::PROTECT,
+            'mode'      => ['shared' => false, 'protected' => true],
             'shared'    => false,
             'protected' => true,
         ];
 
         yield 'not shared, not protected (explicit)' => [
-            'mode'      => ContainerResource::NO_SHARE | ContainerResource::NO_PROTECT,
+            'mode'      => ['shared' => false, 'protected' => false],
             'shared'    => false,
             'protected' => false,
         ];
 
         yield 'shared, not protected (implicit)' => [
-            'mode'      => ContainerResource::SHARE,
+            'mode'      => [ 'shared' => true ],
             'shared'    => true,
             'protected' => false,
         ];
 
         yield 'not shared, protected (implicit)' => [
-            'mode'      => ContainerResource::PROTECT,
+            'mode'      => [ 'protected' => true ],
             'shared'    => false,
             'protected' => true,
         ];
 
         yield 'not shared, not protected (implicit)' => [
-            'mode'      => null,
+            'mode'      => [],
             'shared'    => false,
             'protected' => false,
         ];
@@ -71,7 +71,7 @@ class ContainerResourceTest extends TestCase
      *
      * @dataProvider dataInstantiation
      */
-    public function testInstantiation(?int $mode, bool $shared, bool $protected)
+    public function testInstantiation(?array $mode, bool $shared, bool $protected)
     {
         $container = new Container();
 
@@ -119,7 +119,7 @@ class ContainerResourceTest extends TestCase
             static function () {
                 return new Stub6();
             },
-            ContainerResource::NO_SHARE
+            [ 'shared' => false ]
         );
 
         $this->assertNotSame($resource->getInstance(), $resource->getInstance());
@@ -139,7 +139,7 @@ class ContainerResourceTest extends TestCase
             static function () {
                 return new Stub6();
             },
-            ContainerResource::SHARE
+            [ 'shared' => true ]
         );
 
         $this->assertSame($resource->getInstance(), $resource->getInstance());
@@ -158,7 +158,7 @@ class ContainerResourceTest extends TestCase
         $resource  = new ContainerResource(
             $container,
             $stub,
-            ContainerResource::SHARE
+            [ 'shared' => true ]
         );
 
         $this->assertSame($stub, $resource->getInstance());
@@ -177,7 +177,7 @@ class ContainerResourceTest extends TestCase
         $resource  = new ContainerResource(
             $container,
             $stub,
-            ContainerResource::NO_SHARE
+            [ 'shared' => false ]
         );
 
         $this->assertNotSame($stub, $resource->getInstance());
@@ -197,7 +197,7 @@ class ContainerResourceTest extends TestCase
             static function () {
                 return new Stub6();
             },
-            ContainerResource::SHARE
+            [ 'shared' => true ]
         );
 
         $one = $resource->getInstance();
@@ -222,7 +222,7 @@ class ContainerResourceTest extends TestCase
         $resource  = new ContainerResource(
             $container,
             $stub,
-            ContainerResource::SHARE
+            [ 'shared' => true ]
         );
 
         $one = $resource->getInstance();

--- a/Tests/ContainerResourceTest.php
+++ b/Tests/ContainerResourceTest.php
@@ -18,6 +18,26 @@ include_once __DIR__ . '/Stubs/stubs.php';
  */
 class ContainerResourceTest extends TestCase
 {
+    /**
+     * @testdox  Throws an exception if unknown option provided
+     *
+     * @covers   Joomla\DI\ContainerResource
+     * @uses     Joomla\DI\Container
+     */
+    public function testUnknownOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown option "unknown" given. Allowed options: shared, protected');
+
+        $stub      = new Stub6();
+        $container = new Container();
+        $resource  = new ContainerResource(
+            $container,
+            $stub,
+            [ 'shared' => true, 'unknown' => true ]
+        );
+    }
+
     public function dataInstantiation(): \Generator
     {
         yield 'shared, protected' => [

--- a/Tests/ContainerSetupTest.php
+++ b/Tests/ContainerSetupTest.php
@@ -91,15 +91,13 @@ class ContainerSetupTest extends TestCase
             'foo',
             static function () {
             },
-            false,
-            true
+            [ 'shared' => false, 'protected' => true ],
         );
         $container->set(
             'foo',
             static function () {
             },
-            false,
-            true
+            [ 'shared' => false, 'protected' => true ],
         );
     }
 
@@ -184,8 +182,7 @@ class ContainerSetupTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            $shared,
-            $protected
+            [ 'shared' => $shared, 'protected' => $protected ]
         );
 
         $this->assertSame($shared, $container->isShared('foo'));
@@ -226,7 +223,7 @@ class ContainerSetupTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            true
+            [ 'shared' => true ]
         );
 
         $this->assertTrue($container->isShared('foo'));
@@ -267,7 +264,7 @@ class ContainerSetupTest extends TestCase
             static function () {
                 return new \stdClass();
             },
-            true
+            [ 'protected' => true ]
         );
 
         $this->assertTrue($container->isShared('foo'));

--- a/Tests/ContainerSetupTest.php
+++ b/Tests/ContainerSetupTest.php
@@ -315,4 +315,44 @@ class ContainerSetupTest extends TestCase
 
         $container->get('foo');
     }
+
+    /**
+     * @testdox  Allows to use $shared and $protected params for BC
+     *
+     * @covers   Joomla\DI\Container
+     * @uses     Joomla\DI\ContainerResource
+     */
+    public function testOptionsBC()
+    {
+        $container = new Container();
+        $container->set(
+            'foo',
+            static function () {
+                return new \stdClass();
+            },
+            true,
+            true
+        );
+        $container->share(
+            'bar',
+            static function () {
+                return new \stdClass();
+            },
+            true
+        );
+        $container->protect(
+            'baz',
+            static function () {
+                return new \stdClass();
+            },
+            true
+        );
+
+        $this->assertTrue($container->isShared('foo'));
+        $this->assertTrue($container->isProtected('foo'));
+
+        $this->assertTrue($container->isShared('bar'));
+
+        $this->assertTrue($container->isProtected('baz'));
+    }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -317,9 +317,14 @@ class Container implements ContainerInterface
      * @since   1.0
      * @throws  DependencyResolutionException if the object could not be built (due to missing information)
      */
-    public function buildObject($resourceName, array $options = [])
+    public function buildObject($resourceName, $options = [])
     {
         static $buildStack = [];
+
+        // BC for removed $shared param
+        if (!is_array($options)) {
+            $options = [ 'shared' => $options ];
+        }
 
         $key = $this->resolveAlias($resourceName);
 
@@ -608,8 +613,13 @@ class Container implements ContainerInterface
      * @since   1.0
      * @throws  ProtectedKeyException  Thrown if the provided key is already set and is protected.
      */
-    public function set($key, $value, array $options = [])
+    public function set($key, $value, $options = [])
     {
+        // BC for removed $shared and $protected params
+        if (!is_array($options)) {
+            $options = [ 'shared' => $options, 'protected' => func_get_arg(3) ];
+        }
+
         $key = $this->resolveAlias($key);
 
         $hasKey = $this->has($key);
@@ -640,8 +650,13 @@ class Container implements ContainerInterface
      *
      * @since   1.0
      */
-    public function protect($key, $value, array $options = [])
+    public function protect($key, $value, $options = [])
     {
+        // BC for removed $shared param
+        if (!is_array($options)) {
+            $options = [ 'shared' => $options ];
+        }
+
         $options['protected'] = true;
 
         return $this->set($key, $value, $options);
@@ -658,8 +673,13 @@ class Container implements ContainerInterface
      *
      * @since   1.0
      */
-    public function share($key, $value, array $options = [])
+    public function share($key, $value, $options = [])
     {
+        // BC for removed $protected param
+        if (!is_array($options)) {
+            $options = [ 'protected' => $options ];
+        }
+
         $options['shared'] = true;
 
         return $this->set($key, $value, $options);

--- a/src/Container.php
+++ b/src/Container.php
@@ -308,8 +308,8 @@ class Container implements ContainerInterface
      * Creates an instance of the class specified by $resourceName with all dependencies injected.
      * If the dependencies cannot be completely resolved, a DependencyResolutionException is thrown.
      *
-     * @param   string   $resourceName  The class name to build.
-     * @param   boolean  $shared        True to create a shared resource.
+     * @param   string  $resourceName  The class name to build.
+     * @param   array   $options       Resource options.
      *
      * @return  object|false  Instance of class specified by $resourceName with all dependencies injected.
      *                        Returns an object if the class exists and false otherwise
@@ -317,7 +317,7 @@ class Container implements ContainerInterface
      * @since   1.0
      * @throws  DependencyResolutionException if the object could not be built (due to missing information)
      */
-    public function buildObject($resourceName, $shared = false)
+    public function buildObject($resourceName, array $options = [])
     {
         static $buildStack = [];
 
@@ -380,7 +380,7 @@ class Container implements ContainerInterface
             };
         }
 
-        $this->set($key, $callback, $shared);
+        $this->set($key, $callback, $options);
 
         $resource = $this->get($key);
         array_pop($buildStack);
@@ -400,7 +400,7 @@ class Container implements ContainerInterface
      */
     public function buildSharedObject($resourceName)
     {
-        return $this->buildObject($resourceName, true);
+        return $this->buildObject($resourceName, [ 'shared' => true ]);
     }
 
     /**
@@ -438,7 +438,7 @@ class Container implements ContainerInterface
             return $callable($resource->getInstance(), $c);
         };
 
-        $this->set($key, $closure, $resource->isShared());
+        $this->set($key, $closure, [ 'shared' => $resource->isShared() ]);
     }
 
     /**
@@ -599,17 +599,16 @@ class Container implements ContainerInterface
     /**
      * Set a resource to the container. If the value is null the resource is removed.
      *
-     * @param   string   $key        Name of resources key to set.
-     * @param   mixed    $value      Callable function to run or string to retrieve when requesting the specified $key.
-     * @param   boolean  $shared     True to create and store a shared instance.
-     * @param   boolean  $protected  True to protect this item from being overwritten. Useful for services.
+     * @param   string  $key      Name of resources key to set.
+     * @param   mixed   $value    Callable function to run or string to retrieve when requesting the specified $key.
+     * @param   array   $options  Resource options.
      *
      * @return  $this
      *
      * @since   1.0
      * @throws  ProtectedKeyException  Thrown if the provided key is already set and is protected.
      */
-    public function set($key, $value, $shared = false, $protected = false)
+    public function set($key, $value, array $options = [])
     {
         $key = $this->resolveAlias($key);
 
@@ -625,10 +624,7 @@ class Container implements ContainerInterface
             return $this;
         }
 
-        $mode = $shared ? ContainerResource::SHARE : ContainerResource::NO_SHARE;
-        $mode |= $protected ? ContainerResource::PROTECT : ContainerResource::NO_PROTECT;
-
-        $this->resources[$key] = new ContainerResource($this, $value, $mode);
+        $this->resources[$key] = new ContainerResource($this, $value, $options);
 
         return $this;
     }
@@ -636,33 +632,37 @@ class Container implements ContainerInterface
     /**
      * Shortcut method for creating protected keys.
      *
-     * @param   string   $key     Name of dataStore key to set.
-     * @param   mixed    $value   Callable function to run or string to retrieve when requesting the specified $key.
-     * @param   boolean  $shared  True to create and store a shared instance.
+     * @param   string  $key      Name of dataStore key to set.
+     * @param   mixed   $value    Callable function to run or string to retrieve when requesting the specified $key.
+     * @param   array   $options  Resource options.
      *
      * @return  $this
      *
      * @since   1.0
      */
-    public function protect($key, $value, $shared = false)
+    public function protect($key, $value, array $options = [])
     {
-        return $this->set($key, $value, $shared, true);
+        $options['protected'] = true;
+
+        return $this->set($key, $value, $options);
     }
 
     /**
      * Shortcut method for creating shared keys.
      *
-     * @param   string   $key        Name of dataStore key to set.
-     * @param   mixed    $value      Callable function to run or string to retrieve when requesting the specified $key.
-     * @param   boolean  $protected  True to protect this item from being overwritten. Useful for services.
+     * @param   string  $key      Name of dataStore key to set.
+     * @param   mixed   $value    Callable function to run or string to retrieve when requesting the specified $key.
+     * @param   array   $options  Resource options.
      *
      * @return  $this
      *
      * @since   1.0
      */
-    public function share($key, $value, $protected = false)
+    public function share($key, $value, array $options = [])
     {
-        return $this->set($key, $value, true, $protected);
+        $options['shared'] = true;
+
+        return $this->set($key, $value, $options);
     }
 
     /**
@@ -687,7 +687,7 @@ class Container implements ContainerInterface
         }
 
         if ($this->parent instanceof ContainerInterface && $this->parent->has($key)) {
-            return new ContainerResource($this, $this->parent->get($key), ContainerResource::SHARE | ContainerResource::PROTECT);
+            return new ContainerResource($this, $this->parent->get($key), [ 'shared' => true, 'protected' => true ]);
         }
 
         if ($bail) {

--- a/src/ContainerResource.php
+++ b/src/ContainerResource.php
@@ -18,38 +18,6 @@ namespace Joomla\DI;
 final class ContainerResource
 {
     /**
-     * Defines the resource as non-shared
-     *
-     * @const  integer
-     * @since  2.0.0
-     */
-    public const NO_SHARE = 0;
-
-    /**
-     * Defines the resource as shared
-     *
-     * @const  integer
-     * @since  2.0.0
-     */
-    public const SHARE = 1;
-
-    /**
-     * Defines the resource as non-protected
-     *
-     * @const  integer
-     * @since  2.0.0
-     */
-    public const NO_PROTECT = 0;
-
-    /**
-     * Defines the resource as protected
-     *
-     * @const  integer
-     * @since  2.0.0
-     */
-    public const PROTECT = 2;
-
-    /**
      * The container the resource is assigned to
      *
      * @var    Container
@@ -94,15 +62,15 @@ final class ContainerResource
      *
      * @param   Container  $container  The container
      * @param   mixed      $value      The resource or its factory closure
-     * @param   integer    $mode       Resource mode, defaults to Resource::NO_SHARE | Resource::NO_PROTECT
+     * @param   integer    $options    Resource options, defaults to [ 'protected' => false, 'shared' => false ]
      *
      * @since   2.0.0
      */
-    public function __construct(Container $container, $value, int $mode = 0)
+    public function __construct(Container $container, $value, array $options = [])
     {
         $this->container = $container;
-        $this->shared    = ($mode & self::SHARE) === self::SHARE;
-        $this->protected = ($mode & self::PROTECT) === self::PROTECT;
+        $this->shared    = $options['shared'] ?? false;
+        $this->protected = $options['protected'] ?? false;
 
         if (\is_callable($value)) {
             $this->factory = $value;

--- a/src/ContainerResource.php
+++ b/src/ContainerResource.php
@@ -69,6 +69,18 @@ final class ContainerResource
     public function __construct(Container $container, $value, array $options = [])
     {
         $this->container = $container;
+
+        $allowedOptions = ['shared', 'protected'];
+        foreach (array_keys($options) as $option) {
+            if (!in_array($option, $allowedOptions)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Unknown option "%s" given. Allowed options: %s',
+                    $option,
+                    implode(', ', $allowedOptions)
+                ));
+            }
+        }
+
         $this->shared    = $options['shared'] ?? false;
         $this->protected = $options['protected'] ?? false;
 


### PR DESCRIPTION
The current design of the `Container` class lacks extensibility. For example, it's not possible to add a new type of service (e.g. [lazy services](https://github.com/joomla-framework/di/pull/58)) without dirty hacks or BC breaks.

### Summary of Changes

This PR replaces the use of `$mode`, `$shared` and `$protected` parameters with a single plain `$options` array.

```php
$container->set(
    'foo',
    fn () => new \stdClass(),
    [ 'shared' => true, 'protected' => true ]
);

$container->share(
    'foo',
    fn () => new \stdClass(),
    [ 'protected' => true ]
);

$container->protect(
    'foo',
    fn () => new \stdClass(),
    [ 'shared' => true ]
);
```

It allows us to easily add new types of services and options in the future:

```php
$container->set(
    'foo',
    fn () => new \stdClass(),
    [ 'shared' => true, 'protected' => true, 'lazy' => true ]
);
```

### Testing Instructions

Launch `phpunit` and ensure that the tests are passed.

### Documentation Changes Required

Yes