### PR TITLE
[3.x] Improve resource extending

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -431,14 +431,9 @@ class Container implements ContainerInterface
      */
     public function extend($resourceName, callable $callable)
     {
-        $key      = $this->resolveAlias($resourceName);
-        $resource = $this->getResource($key, true);
+        $key = $this->resolveAlias($resourceName);
 
-        $closure = function ($c) use ($callable, $resource) {
-            return $callable($resource->getInstance(), $c);
-        };
-
-        $this->set($key, $closure, $resource->isShared());
+        $this->getResource($key, true)->extend($callable);
     }
 
     /**

--- a/src/ContainerResource.php
+++ b/src/ContainerResource.php
@@ -9,6 +9,8 @@
 
 namespace Joomla\DI;
 
+use Joomla\DI\Exception\ProtectedKeyException;
+
 /**
  * Defines the representation of a resource.
  *
@@ -182,6 +184,29 @@ final class ContainerResource
     public function getFactory(): callable
     {
         return $this->factory;
+    }
+
+    /**
+     * Extend the resource with a decorator
+     *
+     * @param   callable  $callable  A closure to wrap the existing factory.
+     *                               Receives the original instance and container as arguments.
+     *
+     * @return  void
+     *
+     * @throws  ProtectedKeyException  If the resource is protected
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function extend(callable $callable): void
+    {
+        if ($this->protected) {
+            throw new ProtectedKeyException("Cannot extend a protected resource.");
+        }
+
+        $factory = $this->factory;
+
+        $this->factory = fn(Container $container) => $callable($factory($container), $container);
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes

This PR adds a new method `ContainerResource::extend()`  to extend resources in more efficient way. We don't need to create new resource every time the resource is extending. We can simple wrap the current factory. It makes code more clean and readable.

### Testing Instructions

Unit tests pass

### Documentation Changes Required

No
