### PR TITLE
Support proxies with new class parameter

### DIFF
--- a/Tests/ContainerResourceTest.php
+++ b/Tests/ContainerResourceTest.php
@@ -233,4 +233,68 @@ class ContainerResourceTest extends TestCase
 
         $this->assertNotSame($one, $two);
     }
+
+	/**
+     * @testdox  If the resource is created with a proxy class, the instance is created on first use
+     *
+     * @covers   Joomla\DI\ContainerResource
+     * @uses     Joomla\DI\Container
+     */
+    public function testGetInstanceAsProxy()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Lazy objects are only supported in PHP 8.4 or newer.');
+        }
+
+        $container = new Container();
+
+        $factoryCalled = false;
+
+        $resource = new ContainerResource(
+            $container,
+            static function() use (&$factoryCalled) {
+                $factoryCalled = true;
+                return new Stub6('test');
+            },
+            0,
+            Stub6::class
+        );
+
+        $stub = $resource->getInstance();
+
+        $this->assertTrue((new \ReflectionClass(Stub6::class))->isUninitializedLazyObject($stub) );
+        $this->assertFalse($factoryCalled);
+    }
+
+	/**
+     * @testdox  If the resource is created with an invalid proxy class, the instance is created on first use
+     *
+     * @covers   Joomla\DI\ContainerResource
+     * @uses     Joomla\DI\Container
+     */
+    public function testGetInstanceWithInvalidProxyClass()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Lazy objects are only supported in PHP 8.4 or newer.');
+        }
+
+        $container = new Container();
+
+        $factoryCalled = false;
+
+        $resource = new ContainerResource(
+            $container,
+            static function() use (&$factoryCalled) {
+                $factoryCalled = true;
+                return new Stub6('test');
+            },
+            0,
+            'invalid'
+        );
+
+        $stub = $resource->getInstance();
+
+        $this->assertTrue($stub instanceof Stub6);
+        $this->assertTrue($factoryCalled);
+    }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -603,13 +603,14 @@ class Container implements ContainerInterface
      * @param   mixed    $value      Callable function to run or string to retrieve when requesting the specified $key.
      * @param   boolean  $shared     True to create and store a shared instance.
      * @param   boolean  $protected  True to protect this item from being overwritten. Useful for services.
+     * @param   string   $proxyClass The class to create the proxy for.
      *
      * @return  $this
      *
      * @since   1.0
      * @throws  ProtectedKeyException  Thrown if the provided key is already set and is protected.
      */
-    public function set($key, $value, $shared = false, $protected = false)
+    public function set($key, $value, $shared = false, $protected = false, ?string $proxyClass = '')
     {
         $key = $this->resolveAlias($key);
 
@@ -628,7 +629,7 @@ class Container implements ContainerInterface
         $mode = $shared ? ContainerResource::SHARE : ContainerResource::NO_SHARE;
         $mode |= $protected ? ContainerResource::PROTECT : ContainerResource::NO_PROTECT;
 
-        $this->resources[$key] = new ContainerResource($this, $value, $mode);
+        $this->resources[$key] = new ContainerResource($this, $value, $mode, $proxyClass);
 
         return $this;
     }
@@ -639,14 +640,15 @@ class Container implements ContainerInterface
      * @param   string   $key     Name of dataStore key to set.
      * @param   mixed    $value   Callable function to run or string to retrieve when requesting the specified $key.
      * @param   boolean  $shared  True to create and store a shared instance.
+     * @param   string   $proxyClass The class to create the proxy for.
      *
      * @return  $this
      *
      * @since   1.0
      */
-    public function protect($key, $value, $shared = false)
+    public function protect($key, $value, $shared = false, ?string $proxyClass = '')
     {
-        return $this->set($key, $value, $shared, true);
+        return $this->set($key, $value, $shared, true, $proxyClass);
     }
 
     /**
@@ -655,28 +657,30 @@ class Container implements ContainerInterface
      * @param   string   $key        Name of dataStore key to set.
      * @param   mixed    $value      Callable function to run or string to retrieve when requesting the specified $key.
      * @param   boolean  $protected  True to protect this item from being overwritten. Useful for services.
+     * @param   string   $proxyClass The class to create the proxy for.
      *
      * @return  $this
      *
      * @since   1.0
      */
-    public function share($key, $value, $protected = false)
+    public function share($key, $value, $protected = false, ?string $proxyClass = '')
     {
-        return $this->set($key, $value, true, $protected);
+        return $this->set($key, $value, true, $protected, $proxyClass);
     }
 
     /**
      * Get the raw data assigned to a key.
      *
-     * @param   string   $key   The key for which to get the stored item.
-     * @param   boolean  $bail  Throw an exception, if the key is not found
+     * @param   string   $key        The key for which to get the stored item.
+     * @param   boolean  $bail       Throw an exception, if the key is not found
+     * @param   string   $proxyClass The class to create the proxy for.
      *
      * @return  ContainerResource|null  The resource if present, or null if instructed to not bail
      *
      * @since   2.0.0
      * @throws  KeyNotFoundException
      */
-    public function getResource(string $key, bool $bail = false): ?ContainerResource
+    public function getResource(string $key, bool $bail = false, ?string $proxyClass = ''): ?ContainerResource
     {
         if (isset($this->resources[$key])) {
             return $this->resources[$key];
@@ -687,7 +691,7 @@ class Container implements ContainerInterface
         }
 
         if ($this->parent instanceof ContainerInterface && $this->parent->has($key)) {
-            return new ContainerResource($this, $this->parent->get($key), ContainerResource::SHARE | ContainerResource::PROTECT);
+            return new ContainerResource($this, $this->parent->get($key), ContainerResource::SHARE | ContainerResource::PROTECT, $proxyClass);
         }
 
         if ($bail) {

--- a/src/ContainerResource.php
+++ b/src/ContainerResource.php
@@ -108,7 +108,7 @@ final class ContainerResource
         if (\is_callable($value)) {
             $this->factory = $value;
             if ($proxyClass && class_exists($proxyClass, false) && PHP_VERSION_ID >= 80400) {
-				$this->factory = fn () => (new \ReflectionClass($proxyClass))->newLazyProxy(fn () => $value($this->container));
+                $this->factory = fn () => (new \ReflectionClass($proxyClass))->newLazyProxy(fn () => $value($this->container));
             }
         } else {
             if ($this->shared) {

--- a/src/ContainerResource.php
+++ b/src/ContainerResource.php
@@ -95,10 +95,11 @@ final class ContainerResource
      * @param   Container  $container  The container
      * @param   mixed      $value      The resource or its factory closure
      * @param   integer    $mode       Resource mode, defaults to Resource::NO_SHARE | Resource::NO_PROTECT
+     * @param   string     $proxyClass The class to create the proxy for, is only used when $value is a callable
      *
      * @since   2.0.0
      */
-    public function __construct(Container $container, $value, int $mode = 0)
+    public function __construct(Container $container, $value, int $mode = 0, ?string $proxyClass = '')
     {
         $this->container = $container;
         $this->shared    = ($mode & self::SHARE) === self::SHARE;
@@ -106,6 +107,9 @@ final class ContainerResource
 
         if (\is_callable($value)) {
             $this->factory = $value;
+            if ($proxyClass && class_exists($proxyClass, false) && PHP_VERSION_ID >= 80400) {
+				$this->factory = fn () => (new \ReflectionClass($proxyClass))->newLazyProxy(fn () => $value($this->container));
+            }
         } else {
             if ($this->shared) {
                 $this->instance = $value;


### PR DESCRIPTION
Alternative to #58. A new parameter is added which allows to define the class to proxy. A service can then be defined in such a way:

```
$container = new Container();
$container->set('foo', fn ($container) => new \stdClass(), false, false, \stdClass::class);

$obj = $container->get('foo'); // The $obj class s a proxy instance till it is used the first time
$ob->bar; // This will instantiate the class and nob $obj is a stdClass object
```

the callback function (second argument) will not be called before the first access will be done on the returned object.

## Breaks backwards compatibility
Classes which extend the container and do override the set, protect, share and getResource functions must add the new parameter.
