### PR TITLE
Allow to set key for lazy service

### DIFF
--- a/Tests/ContainerSetupTest.php
+++ b/Tests/ContainerSetupTest.php
@@ -327,7 +327,7 @@ class ContainerSetupTest extends TestCase
     public function testCreateLazyProxy()
     {
         $container = new Container();
-        $container->lazy(Stub6::class, function () {
+        $container->lazy(Stub6::class, Stub6::class, function () {
             return new Stub6();
         });
 
@@ -350,7 +350,7 @@ class ContainerSetupTest extends TestCase
         $factoryCalled = false;
 
         $container = new Container();
-        $container->lazy(Stub6::class, function () use (&$factoryCalled) {
+        $container->lazy(Stub6::class, Stub6::class, function () use (&$factoryCalled) {
             $factoryCalled = true;
             return new Stub6();
         });

--- a/src/Container.php
+++ b/src/Container.php
@@ -668,6 +668,7 @@ class Container implements ContainerInterface
     /**
      * Create a lazy proxy resource for given class, and register it in the Container.
      *
+     * @param   string         $key        The unique identifier for the resource.
      * @param   string         $class      Full class name of the resource.
      * @param   callable       $factory    Callback to create the class instance. The callback must return instance of the given class.
      * @param   boolean        $shared     True to create and store a shared instance.
@@ -677,10 +678,10 @@ class Container implements ContainerInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    final public function lazy(string $class, callable $factory, bool $shared = false, bool $protected = false): static
+    final public function lazy(string $key, string $class, callable $factory, bool $shared = false, bool $protected = false): static
     {
         if (PHP_VERSION_ID < 80400) {
-            return $this->set($class, $factory, $shared, $protected);
+            return $this->set($key, $factory, $shared, $protected);
         }
 
         // Create a Lazy Proxy factory
@@ -690,7 +691,7 @@ class Container implements ContainerInterface
             });
         };
 
-        return $this->set($class, $lazyFactory, $shared, $protected);
+        return $this->set($key, $lazyFactory, $shared, $protected);
     }
 
     /**


### PR DESCRIPTION
Now it's not possible to define multiple lazy services with the same FQDN.

For example, how to create two different lazy database connections?

```php
// First connection
$container->lazy(Database::class);

// Second connection overwrites the first one
$container->lazy(Database::class);
```

### Summary of Changes

A new `key` parameter has been added to the `lazy()` method to allow users to specify a service identifier:

```php
// Default connection
$container->lazy(DatabaseInterface::class, Database::class);

// Second connection
$container->lazy('connection2', Database::class);
```
