### PR TITLE
[3.x] Prepare 3.1.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# IDE & System Related Files
+.buildpath
+.project
+.settings
+.DS_Store
+.idea
+.vscode
+.docker
+
+# OSX
+._*
+.Spotlight-V100
+.Trashes
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# Project specific
 vendor/
 composer.phar
 composer.lock

--- a/src/Container.php
+++ b/src/Container.php
@@ -673,7 +673,7 @@ class Container implements ContainerInterface
      *
      * @return  callable
      *
-     * @since   __DEPLOY_VERSION__
+     * @since   3.1.0
      */
     final public function lazy(string $class, callable $factory): callable
     {


### PR DESCRIPTION
This pull request (PR) prepares the next 3.1.0 release by
- Doing an upmerge from 2.0-dev (which results in no change as the same change has already been applied on 3.x-dev but will update the commit history so 2.0-dev is not shown anymore to be in advance to 3.x-dev).
- Updating the `@since` tag of the new method added with PR #64 .

As the lazy objects helper added with PR #64 is a new feature, the next version will be a new minor.